### PR TITLE
add the ShiftPath function

### DIFF
--- a/shift.go
+++ b/shift.go
@@ -1,0 +1,23 @@
+package hutil
+
+import (
+	"path"
+	"strings"
+)
+
+// ShiftPath splits the path into the first component and the rest of
+// the path.
+// The returned head will never have a slash in it, if the path has no tail head will be empty.
+// The tail will never have a trailing slash.
+func ShiftPath(p string) (head string, tail string) {
+	p = path.Clean("/" + p)
+
+	pos := strings.Index(p[1:], "/")
+	if pos == -1 {
+		return p[1:], "/"
+	}
+
+	p = p[1:]
+
+	return p[:pos], p[pos:]
+}

--- a/shift_test.go
+++ b/shift_test.go
@@ -1,0 +1,28 @@
+package hutil
+
+import "testing"
+
+func TestShiftPath(t *testing.T) {
+	testCases := []struct {
+		input string
+		head  string
+		tail  string
+	}{
+		{"/copy", "copy", "/"},
+		{"/", "", "/"},
+		{"/api/v1/hello", "api", "/v1/hello"},
+		{".", "", "/"},
+	}
+
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			head, tail := ShiftPath(tc.input)
+			if got, exp := head, tc.head; got != exp {
+				t.Fatalf("expected %q but got %q", exp, got)
+			}
+			if got, exp := tail, tc.tail; got != exp {
+				t.Fatalf("expected %q but got %q", exp, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
implement a ShiftPath function which can be used to easily implement REST path splitting